### PR TITLE
trustedproxy header config settings are being ignored

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -19,11 +19,5 @@ class TrustProxies extends Middleware
      *
      * @var array
      */
-    protected $headers = [
-        Request::HEADER_FORWARDED => 'FORWARDED',
-        Request::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
-        Request::HEADER_X_FORWARDED_HOST => 'X_FORWARDED_HOST',
-        Request::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
-        Request::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
-    ];
+    protected $headers;
 }


### PR DESCRIPTION
The fideloper trusted proxy middleware was included with Laravel 5.5. Great! Need that when running behind AWS Load Balancers.

However, in vendor/fideloper/proxy/src/TrustedProxies.php, the protected variable $headers is declared, but not explicitly set, so it gets a null value.  Then, in that class' getTrustedHeaderNames function it does:

return $this->headers ?: $this->config->get('trustedproxy.headers');

All good, if the headers are not explicitly set, use the values from the config file.

However, the Laravel middleware file that derives from this, app/Http/Middleware/TrustProxies.php explicitly sets the headers variable, so the inherited getTrustedHeaderNames method unconditionally returns the values from that file and totally ignores the settings from the config file.

Demo the problem by setting the the FORWARDED header to null in the config file (the recommended setting for AWS)

    'headers' => [
        Illuminate\Http\Request::HEADER_FORWARDED    => null,
        Illuminate\Http\Request::HEADER_CLIENT_IP    => 'X_FORWARDED_FOR',
        Illuminate\Http\Request::HEADER_CLIENT_HOST  => null,
        Illuminate\Http\Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
        Illuminate\Http\Request::HEADER_CLIENT_PORT  => 'X_FORWARDED_PORT',
    ]

and making sure that "proxies" is set to '*", then run

curl --header 'Forwarded: for=192.168.111.111'  --header 'X-Forwarded-For: 192.168.222.222' 'http://anyValidRouteOnYourSite'

This will result in an error: "The request has both a trusted "FORWARDED" header and a trusted "X_FORWARDED_FOR" header, conflicting with each other. You should either configure your proxy to remove one of them, or configure your project to distrust the offending one." Even though you configured it to ignore the FORWARDED header.  (If your server is behind an AWS load balancer, you can leave out the X-Forwarded-For from the curl command as the LB will add it.)

Seems to me that the way fideloper trusted proxy middleware is architected, you should set the trusted headers either explicitly in the middleware, or in the config file, but not both. Config file seems to make more sense?